### PR TITLE
Remove `postinstall` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
 		"lint:fix": "eslint --fix --ext .js,.ts .",
 		"prebuild": "rimraf dist",
 		"prepare": "husky install",
-		"postinstall": "yarn build",
 		"test": "jest --config=./test/unit/jest.config.js",
 		"test:ci": "jest --coverage=true --coverage-reporters=json --verbose",
 		"test:coverage": "jest --config=./test/unit/jest.config.js --coverage=true --coverage-reporters=text",


### PR DESCRIPTION
This script causes an error when installing package from NPM:

```bash
anon@anon:~/tmp/web3-chainlink-plugin-test$ YARN_REGISTRY="http://localhost:4873" yarn add @chainsafe/web3.js-chainlink-plugin
yarn add v1.22.19
warning ../../package.json: No license field
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > @chainsafe/web3.js-chainlink-plugin@0.2.0" has unmet peer dependency "web3-eth@>= 4.0.1-alpha.0 < 5".
warning " > @chainsafe/web3.js-chainlink-plugin@0.2.0" has unmet peer dependency "web3-eth-abi@>= 4.0.1-alpha.0 < 5".
warning " > @chainsafe/web3.js-chainlink-plugin@0.2.0" has unmet peer dependency "web3-eth-contract@>= 4.0.1-alpha.0 < 5".
warning " > @chainsafe/web3.js-chainlink-plugin@0.2.0" has unmet peer dependency "web3-types@>= 0.1.1-alpha.0 < 5".
warning " > @chainsafe/web3.js-chainlink-plugin@0.2.0" has unmet peer dependency "web3-validator@>= 0.1.1-alpha.0 < 5".
[4/4] Building fresh packages...
error /home/anon/tmp/web3-chainlink-plugin-test/node_modules/@chainsafe/web3.js-chainlink-plugin: Command failed.
Exit code: 127
Command: yarn build
Arguments: 
Directory: /home/anon/tmp/web3-chainlink-plugin-test/node_modules/@chainsafe/web3.js-chainlink-plugin
Output:
yarn run v1.22.19
warning ../../../../../package.json: No license field
$ rimraf dist
/bin/sh: 1: rimraf: not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

Because it tries to run `"postinstall": "yarn build",`