### PR TITLE
Fix: to the not found link on information for registering plugin in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const chainlinkPlugin = new ChainlinkPlugin();
 web3.registerPlugin(chainlinkPlugin);
 ```
 
-More information about registering web3.js plugins can be found [here](https://docs.web3js.org/docs/guides/web3_plugin_guide/plugin_users#registering-the-plugin).
+More information about registering web3.js plugins can be found [here]([https://docs.web3js.org/docs/guides/web3_plugin_guide/plugin_users#registering-the-plugin](https://docs.web3js.org/guides/web3_plugin_guide/plugin_authors/)).
 
 ### Plugin Methods
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const chainlinkPlugin = new ChainlinkPlugin();
 web3.registerPlugin(chainlinkPlugin);
 ```
 
-More information about registering web3.js plugins can be found [here]([https://docs.web3js.org/docs/guides/web3_plugin_guide/plugin_users#registering-the-plugin](https://docs.web3js.org/guides/web3_plugin_guide/plugin_authors/)).
+More information about registering web3.js plugins can be found [here](https://docs.web3js.org/guides/web3_plugin_guide/plugin_authors/).
 
 ### Plugin Methods
 


### PR DESCRIPTION
Closes issue - #35 

Changed the link from - https://docs.web3js.org/docs/guides/web3_plugin_guide/plugin_users#registering-the-plugin

To the correct link - https://docs.web3js.org/guides/web3_plugin_guide/plugin_authors/